### PR TITLE
Typo found by codespell: trasparent -> transparent

### DIFF
--- a/blogs/static/blogs/css/homestyle.css
+++ b/blogs/static/blogs/css/homestyle.css
@@ -194,7 +194,7 @@ position:fixed;
 
 
 .like {
-  background-color: trasparent;
+  background-color: transparent;
   border: none;
   color: red ;
   text-align: center;


### PR DESCRIPTION
Typo discovered in #1