### PR TITLE
lint_python.yml: Require codespell to pass

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -22,7 +22,7 @@ jobs:
       #  run: |
       #    pip install black
       #    black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       # isort and reorder-python-imports are two ways of doing the same thing
       - run: isort --recursive . || true


### PR DESCRIPTION
Typos will now cause our automated tests to fail.